### PR TITLE
Rename Snacks category to Snacks & Sides on all-recipes page

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@
           <span class="category-emoji"><img src="images/category-pasta.png" alt="" class="category-icon-image" aria-hidden="true"></span>
           <span class="category-name">Pasta</span>
         </a>
-        <a href="recipes-list.html?category=Snacks" class="category-tile">
+        <a href="recipes-list.html?category=Snacks%20%26%20Sides" class="category-tile">
           <span class="category-emoji"><img src="images/category-snacks-and-apps.png" alt="" class="category-icon-image" aria-hidden="true"></span>
           <span class="category-name">Snacks & Sides</span>
         </a>
@@ -141,7 +141,7 @@
           <span class="category-emoji"><img src="images/category-pasta.png" alt="" class="category-icon-image" aria-hidden="true"></span>
           <span class="category-name">Pasta</span>
         </a>
-        <a href="recipes-list.html?category=Snacks" class="category-tile">
+        <a href="recipes-list.html?category=Snacks%20%26%20Sides" class="category-tile">
           <span class="category-emoji"><img src="images/category-snacks-and-apps.png" alt="" class="category-icon-image" aria-hidden="true"></span>
           <span class="category-name">Snacks & Sides</span>
         </a>

--- a/recipes-data.js
+++ b/recipes-data.js
@@ -101,7 +101,7 @@
   title: "Sodium Citrate Pepper Jack Queso (Eva’s Chili-Spiced Version)",
   description: "Ultra-smooth, pourable queso made with real cheese, light dairy, and sodium citrate — kid-approved but flavor-forward.",
   image: "images/sodium-citrate-queso-dip.png",
-  category: "Snacks",
+  category: "Snacks & Sides",
   dateAdded: "2026-02-04",
   calories: "",
   protein: "",


### PR DESCRIPTION
## Summary

- Updates the queso recipe's category from `"Snacks"` to `"Snacks & Sides"` in `recipes-data.js` so the filter button on the all-recipes page reads "Snacks & Sides" and the category pill on the recipe card matches
- Updates the homepage category tile links from `?category=Snacks` to `?category=Snacks%20%26%20Sides` so clicking the tile still correctly filters to that category

## Test plan

- [ ] All-recipes page filter buttons show "Snacks & Sides" (not "Snacks")
- [ ] Clicking "Snacks & Sides" filter shows the queso recipe
- [ ] Recipe card for the queso shows "Snacks & Sides" category pill
- [ ] Clicking "Snacks & Sides" tile on homepage navigates to all-recipes filtered to that category

---
_Generated by [Claude Code](https://claude.ai/code/session_01BeEmf6jYsnSqKP4FXA8Vpt)_