### PR TITLE
Add servings to Family Style American Goulash recipe

### DIFF
--- a/recipes-data.js
+++ b/recipes-data.js
@@ -901,6 +901,7 @@ tags: ["dessert", "high protein"]
   fiber: null,
   calories: "265",
   protein: "24 g",
+  servings: "6",
   tags: ["soup", "protein", "ground beef"],
 
   ingredients: [


### PR DESCRIPTION
Without a servings count, nutrition info was calculating per the
whole pot instead of per serving.