### PR TITLE
Remove incorrect Greek yogurt suggestion from lobster bisque notes

### DIFF
--- a/recipes-data.js
+++ b/recipes-data.js
@@ -302,7 +302,7 @@ tags: ["dessert", "high protein"]
   notes: [
     "Great with grilled cheese or crusty bread.",
     "For extra richness, swap part of the milk for heavy cream.",
-    "For extra protein, stir in a spoon of greek yogurt off-heat before serving or add extra minced lobster meat on top."
+    "Top with extra minced lobster meat for a heartier bowl."
   ]
 },
 


### PR DESCRIPTION
Replace the note suggesting Greek yogurt for extra protein with a
simpler note about topping with extra minced lobster meat.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GDXAJykFcMAcPvzMrjJdaK