### PR TITLE
Add servings: 4 to Air Fryer General Tso's Chicken recipe

### DIFF
--- a/recipes-data.js
+++ b/recipes-data.js
@@ -313,6 +313,7 @@ tags: ["dessert", "high protein"]
   image: "images/air-fryer-general-tsos-chicken.png",
   category: "Chicken",
   dateAdded: "2026-02-11",
+  servings: "4",
   carbs: null,
   fat: null,
   fiber: null,


### PR DESCRIPTION
Without a servings count the nutrition calculation treated the whole batch
as one serving. Setting servings to 4 aligns the per-serving macros with
the existing calorie/protein notes on the recipe.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WFjfgsKuVk78yFMX8Meta2