### PR TITLE
Add servings: 6 to basmati rice recipe so nutrition shows per-serving

### DIFF
--- a/recipes-data.js
+++ b/recipes-data.js
@@ -871,6 +871,7 @@ tags: ["dessert", "high protein"]
   carbs: null,
   fat: null,
   fiber: null,
+  servings: "6",
   tags: ["rice", "rice cooker", "side dishes"],
 
   ingredients: [


### PR DESCRIPTION
Without a servings value the app divides totals by 1, showing calories
for the whole pot. Setting servings to 6 makes the per-serving calorie
count correct.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01S57tnyunFW2aSDnQpMU3aM