### PR TITLE
Add servings to Honey Mustard Chicken Thighs recipe

### DIFF
--- a/recipes-data.js
+++ b/recipes-data.js
@@ -952,6 +952,7 @@ tags: ["dessert", "high protein"]
   fiber: null,
   calories: "520 per 2 chicken thighs",
   protein: "52 g",
+  servings: "5",
   tags: ["chicken", "protein", "easy", "weeknight"],
 
   ingredients: [


### PR DESCRIPTION
Sets servings to 5 for the honey mustard chicken thighs recipe,
which was previously missing this field.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018vjtcBiYiyXtjumNygyiKw