### PR TITLE
Convert soy sauce measurement to volume in sauce recipe

### DIFF
--- a/recipes-data.js
+++ b/recipes-data.js
@@ -1269,7 +1269,7 @@ tags: ["dessert", "high protein"]
     {
       title: "The Sauce",
       items: [
-        { qty: 6, unit: "tbsp", name: "soy sauce", notes: "plus 2 tsp" },
+        { qty: 1/3, unit: "cup", name: "soy sauce", notes: "plus 4 tsp" },
         { qty: 4, unit: "tbsp", name: "brown sugar" },
         { qty: 1.5, unit: "tbsp", name: "toasted sesame oil" },
         { qty: 6, unit: "clove", name: "garlic", notes: "minced" },


### PR DESCRIPTION
## Summary
Updated the soy sauce measurement in "The Sauce" recipe component from weight/count (6 tbsp) to volume (1/3 cup), with a corresponding adjustment to the additional amount noted.

## Changes
- Changed soy sauce quantity from `6 tbsp` to `1/3 cup` (equivalent volume conversion)
- Updated the notes field from `"plus 2 tsp"` to `"plus 4 tsp"` to maintain the total amount

## Details
This is a measurement standardization change that converts the soy sauce ingredient to a more standard volume measurement while preserving the total quantity called for in the recipe.

https://claude.ai/code/session_014mr6GgL1ZzxBS7QsLpviBG