### PR TITLE
Improve meatloaf recipe: specify salt/pepper and cooking time

### DIFF
--- a/recipes-data.js
+++ b/recipes-data.js
@@ -237,7 +237,8 @@ tags: ["dessert", "high protein"]
     { qty: 1, unit: "tsp", name: "Worcestershire sauce" },
     { qty: 0.5, unit: "tsp", name: "garlic powder" },
     { qty: 0.5, unit: "tsp", name: "onion powder" },
-    { qty: null, unit: null, name: "Salt and pepper, to taste" },
+    { qty: 0.5, unit: "tsp", name: "salt" },
+    { qty: 0.25, unit: "tsp", name: "black pepper" },
     { qty: 1, unit: "tbsp", name: "olive oil" },
 
     { qty: 2, unit: null, name: "packets brown gravy mix" },
@@ -249,7 +250,7 @@ tags: ["dessert", "high protein"]
   steps: [
     "Combine ground beef, bread crumbs, ketchup, mustard, Worcestershire, garlic powder, onion powder, salt, and pepper in a large bowl. Mix gently by hand.",
     "Heat olive oil in a large skillet over medium heat.",
-    "Form meat mixture into patties and cook on both sides until no longer pink.",
+    "Form meat mixture into patties and then cook on both sides, 4-5 minutes per side,  until no longer pink.",
     "Lower heat to low.",
     "Whisk gravy mix with hot water until smooth, then whisk in ketchup and Worcestershire.",
     "Pour gravy over patties and let simmer until heated through and thickened."


### PR DESCRIPTION
## Summary
Updated the meatloaf recipe to provide more precise ingredient measurements and clearer cooking instructions.

## Changes
- **Ingredient measurements**: Replaced the generic "Salt and pepper, to taste" with specific quantities:
  - Salt: 0.5 tsp
  - Black pepper: 0.25 tsp
- **Cooking instructions**: Enhanced the patty cooking step to include specific timing (4-5 minutes per side) for better guidance

## Details
These changes improve recipe clarity and consistency by replacing vague "to taste" measurements with measurable quantities, and adding concrete cooking times to help users achieve the intended result. The ingredient list now matches the cooking instructions which already referenced "salt and pepper" as separate items.

https://claude.ai/code/session_01Lajo3bh7qbbLq1pFuAhiCG