### PR TITLE
Remove notes section from BBQ Chicken Baked Potato recipe

### DIFF
--- a/recipes-data.js
+++ b/recipes-data.js
@@ -489,12 +489,6 @@ tags: ["dessert", "high protein"]
     "Slice potatoes open and fluff insides with a fork. Season lightly.",
     "Add butter or yogurt/sour cream, then spoon BBQ chicken over top.",
     "Let everyone customize with cheese, bacon, chives, hot sauce, and serve immediately."
-  ],
-
-  notes: [
-    "Keep it lighter with Greek yogurt, reduced-fat cheese, and skipping bacon.",
-    "Going indulgent? Load it like a steakhouse and live your best life.",
-    "For smaller portions, use medium russets and about 4 oz chicken per potato."
   ]
 },
 


### PR DESCRIPTION
## Summary
Removed the `notes` array from the BBQ Chicken Baked Potato recipe in `recipes-data.js`.

## Changes
- Deleted the `notes` field containing three tip entries about lighter/indulgent variations and portion sizing from the BBQ Chicken Baked Potato recipe

## Notes
This is a straightforward data cleanup that removes optional guidance notes from a single recipe entry. The recipe's core instructions remain intact.

https://claude.ai/code/session_01HvAwv2Gv4vBCNF9chGZb4t