### PR TITLE
Remove non-scaling can-count note from nacho queso evaporated milk

### DIFF
--- a/recipes-data.js
+++ b/recipes-data.js
@@ -1701,7 +1701,7 @@ tags: ["dessert", "high protein"]
     {
       title: "Liquid + Stabilizer",
       items: [
-        { qty: 18, unit: "fl oz", name: "evaporated milk", notes: "about 1½ cans" },
+        { qty: 18, unit: "fl oz", name: "evaporated milk" },
         { qty: 1.5, unit: "tbsp", name: "cornstarch" }
       ]
     },


### PR DESCRIPTION
The "about 1½ cans" note stayed fixed regardless of serving size, so it
became misleading whenever the recipe was scaled.