### PR TITLE
Add condensed color-coded nutrition panel (experimental)

### DIFF
--- a/abc-recipe-detail.html
+++ b/abc-recipe-detail.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="page-type" content="abc-detail" />
   <title>Recipe • Adrien's Baking Corner</title>
-  <link rel="stylesheet" href="styles.css?v=9" />
+  <link rel="stylesheet" href="styles.css?v=10" />
   <link rel="preload" href="images/background-wood.png" as="image" type="image/png" />
 </head>
 <body>

--- a/abc-recipe-detail.html
+++ b/abc-recipe-detail.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="page-type" content="abc-detail" />
   <title>Recipe • Adrien's Baking Corner</title>
-  <link rel="stylesheet" href="styles.css?v=10" />
+  <link rel="stylesheet" href="styles.css?v=11" />
   <link rel="preload" href="images/background-wood.png" as="image" type="image/png" />
 </head>
 <body>

--- a/abc.html
+++ b/abc.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="page-type" content="abc" />
   <title>Adrien's Baking Corner • JoMama's Recipes</title>
-  <link rel="stylesheet" href="styles.css?v=9" />
+  <link rel="stylesheet" href="styles.css?v=10" />
   <link rel="preload" href="images/background-wood.png" as="image" type="image/png" />
 </head>
 <body>

--- a/abc.html
+++ b/abc.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="page-type" content="abc" />
   <title>Adrien's Baking Corner • JoMama's Recipes</title>
-  <link rel="stylesheet" href="styles.css?v=10" />
+  <link rel="stylesheet" href="styles.css?v=11" />
   <link rel="preload" href="images/background-wood.png" as="image" type="image/png" />
 </head>
 <body>

--- a/about.html
+++ b/about.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="page-type" content="about" />
   <title>About • JoMama's Recipes</title>
-  <link rel="stylesheet" href="styles.css?v=9" />
+  <link rel="stylesheet" href="styles.css?v=10" />
   <link rel="preload" href="images/background-wood.png" as="image" type="image/png" />
 </head>
 <body class="about-page">

--- a/about.html
+++ b/about.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="page-type" content="about" />
   <title>About • JoMama's Recipes</title>
-  <link rel="stylesheet" href="styles.css?v=10" />
+  <link rel="stylesheet" href="styles.css?v=11" />
   <link rel="preload" href="images/background-wood.png" as="image" type="image/png" />
 </head>
 <body class="about-page">

--- a/app.js
+++ b/app.js
@@ -67,32 +67,33 @@ function formatRecipeCategories(recipe, separator = ', ') {
 const NUTRITION_FIELDS = ['calories', 'protein', 'fat', 'fiber', 'carbs'];
 
 function renderNutritionSection(recipe) {
-  const formatValue = (value) => (value === null || value === undefined || value === '') ? '—' : value;
   const computedOn = !!window.flagsService?.isEnabled('showComputedNutrition');
+  const panelOn = !!window.flagsService?.isEnabled('nutritionPanelView');
+  const round = (value) => Math.round(value * 10) / 10;
 
-  let display;
+  // Raw per-serving numbers (or null when missing/unknown), shared by both
+  // the plain list and the condensed panel below.
+  let raw;
   if (computedOn) {
     const result = computeRecipeNutrition(recipe);
-    const round = (value) => Math.round(value * 10) / 10;
-    const field = (key, suffix = '') => result.unknown.has(key) ? 'Unknown' : `${round(result.perServing[key])}${suffix}`;
-    display = {
-      calories: field('calories'),
-      protein: field('protein', 'g'),
-      carbs: field('carbs', 'g'),
-      netCarbs: field('netCarbs', 'g'),
-      fat: field('fat', 'g'),
-      fiber: field('fiber', 'g'),
-    };
+    raw = {};
+    [...NUTRITION_FIELDS, 'netCarbs'].forEach((key) => {
+      raw[key] = result.unknown.has(key) ? null : round(result.perServing[key]);
+    });
   } else {
-    display = {
-      calories: formatValue(recipe.calories),
-      protein: formatValue(recipe.protein),
-      carbs: formatValue(recipe.carbs),
-      netCarbs: '—',
-      fat: formatValue(recipe.fat),
-      fiber: formatValue(recipe.fiber),
+    const num = (value) => (value === null || value === undefined || value === '') ? null : value;
+    raw = {
+      calories: num(recipe.calories),
+      protein: num(recipe.protein),
+      carbs: num(recipe.carbs),
+      netCarbs: null,
+      fat: num(recipe.fat),
+      fiber: num(recipe.fiber),
     };
   }
+
+  const missingText = (key) => raw[key] === null ? (computedOn ? 'Unknown' : '—') : null;
+  const listText = (key, suffix = '') => missingText(key) ?? `${raw[key]}${suffix}`;
 
   // The info link only appears when computed nutrition is shown, since
   // that's the data it lets reviewers fact-check.
@@ -100,16 +101,54 @@ function renderNutritionSection(recipe) {
     ? ` <a class="nutrition-info-link" href="nutrition-info.html?id=${recipe.id}" aria-label="Nutrition data, sources, and disclaimer" title="Nutrition data, sources, and disclaimer">ℹ️</a>`
     : '';
 
+  if (panelOn) {
+    const panelText = (key, suffix = '') => missingText(key) ?? `${raw[key]}<span class="nutrition-stat-unit">${suffix}</span>`;
+    // Net carbs (and its subtraction breakdown) only exist once computed
+    // nutrition has resolved every ingredient; a manually entered recipe
+    // only has gross carbs, so the tile falls back to that instead.
+    const carbsKey = computedOn ? 'netCarbs' : 'carbs';
+    const carbsLabel = computedOn ? 'Net Carbs' : 'Carbs';
+    const carbsSub = (computedOn && raw.carbs !== null && raw.fiber !== null && raw.netCarbs !== null)
+      ? `<div class="nutrition-stat-sub">${raw.carbs} − ${raw.fiber}</div>`
+      : '';
+
+    return `
+          <div class="recipe-nutrition">
+            <h3>Nutrition (per serving)${infoLink}</h3>
+            <div class="nutrition-panel-grid">
+              <div class="nutrition-stat nutrition-stat-calories">
+                <div class="nutrition-stat-label">Calories</div>
+                <div class="nutrition-stat-value">${panelText('calories')}</div>
+              </div>
+              <div class="nutrition-panel-macros">
+                <div class="nutrition-stat nutrition-stat-carbs">
+                  <div class="nutrition-stat-label">${carbsLabel}</div>
+                  <div class="nutrition-stat-value">${panelText(carbsKey, 'g')}</div>
+                  ${carbsSub}
+                </div>
+                <div class="nutrition-stat nutrition-stat-protein">
+                  <div class="nutrition-stat-label">Protein</div>
+                  <div class="nutrition-stat-value">${panelText('protein', 'g')}</div>
+                </div>
+                <div class="nutrition-stat nutrition-stat-fat">
+                  <div class="nutrition-stat-label">Fat</div>
+                  <div class="nutrition-stat-value">${panelText('fat', 'g')}</div>
+                </div>
+              </div>
+            </div>
+          </div>`;
+  }
+
   return `
           <div class="recipe-nutrition">
             <h3>Nutrition (per serving)${infoLink}</h3>
             <ul class="nutrition-list">
-              <li><strong>Calories:</strong> ${display.calories}</li>
-              <li><strong>Protein:</strong> ${display.protein}</li>
-              <li><strong>Carbs:</strong> ${display.carbs}</li>
-              <li><strong>Net Carbs:</strong> ${display.netCarbs}</li>
-              <li><strong>Fat:</strong> ${display.fat}</li>
-              <li><strong>Fiber:</strong> ${display.fiber}</li>
+              <li><strong>Calories:</strong> ${listText('calories')}</li>
+              <li><strong>Protein:</strong> ${listText('protein', 'g')}</li>
+              <li><strong>Carbs:</strong> ${listText('carbs', 'g')}</li>
+              <li><strong>Net Carbs:</strong> ${listText('netCarbs', 'g')}</li>
+              <li><strong>Fat:</strong> ${listText('fat', 'g')}</li>
+              <li><strong>Fiber:</strong> ${listText('fiber', 'g')}</li>
             </ul>
           </div>`;
 }

--- a/app.js
+++ b/app.js
@@ -102,23 +102,27 @@ function renderNutritionSection(recipe) {
     : '';
 
   if (panelOn) {
-    const panelText = (key, suffix = '') => missingText(key) ?? `${raw[key]}<span class="nutrition-stat-unit">${suffix}</span>`;
+    // Rounded to whole numbers here (unlike the list view's one-decimal
+    // figures) — the panel trades precision for staying glanceable at a
+    // fraction of the width.
+    const panelText = (key, suffix = '') => missingText(key) ?? `${Math.round(raw[key])}${suffix ? `<span class="nutrition-stat-unit">${suffix}</span>` : ''}`;
     // Net carbs (and its subtraction breakdown) only exist once computed
     // nutrition has resolved every ingredient; a manually entered recipe
     // only has gross carbs, so the tile falls back to that instead.
     const carbsKey = computedOn ? 'netCarbs' : 'carbs';
     const carbsLabel = computedOn ? 'Net Carbs' : 'Carbs';
     const carbsSub = (computedOn && raw.carbs !== null && raw.fiber !== null && raw.netCarbs !== null)
-      ? `<div class="nutrition-stat-sub">${raw.carbs} − ${raw.fiber}</div>`
+      ? `<div class="nutrition-stat-sub">${Math.round(raw.carbs)} − ${Math.round(raw.fiber)}</div>`
       : '';
 
     return `
-          <div class="recipe-nutrition">
-            <h3>Nutrition (per serving)${infoLink}</h3>
+          <div class="recipe-nutrition recipe-nutrition--panel">
             <div class="nutrition-panel-grid">
               <div class="nutrition-stat nutrition-stat-calories">
+                ${infoLink}
                 <div class="nutrition-stat-label">Calories</div>
                 <div class="nutrition-stat-value">${panelText('calories')}</div>
+                <div class="nutrition-stat-sub">per serving</div>
               </div>
               <div class="nutrition-panel-macros">
                 <div class="nutrition-stat nutrition-stat-carbs">
@@ -151,6 +155,45 @@ function renderNutritionSection(recipe) {
               <li><strong>Fiber:</strong> ${listText('fiber', 'g')}</li>
             </ul>
           </div>`;
+}
+
+// Renders the category badge, print/cook-mode buttons, and nutrition
+// section together, since the condensed panel view needs them laid out as
+// one flex row (buttons left, nutrition floated right) while the plain
+// list view keeps its original stacked layout. Shared by all three
+// recipe-detail templates below so the flag check and markup live in one
+// place.
+function renderRecipeMetaSection(recipe) {
+  const panelOn = !!window.flagsService?.isEnabled('nutritionPanelView');
+  const categoryBadge = `<span class="badge">${formatRecipeCategories(recipe, ' • ')}</span>`;
+
+  if (!panelOn) {
+    return `
+        <div class="recipe-meta">
+          <div class="meta-primary">
+            ${categoryBadge}
+            <button class="print-recipe-btn button-family button-primary" id="printRecipeBtn" type="button">Print Recipe</button>
+            <button class="cook-mode-btn button-family button-secondary" id="cookModeBtn" type="button" aria-pressed="false">Cook Mode: Off</button>
+          </div>
+        </div>
+        ${renderNutritionSection(recipe)}
+        <p class="cook-mode-status" id="cookModeStatus" aria-live="polite"></p>`;
+  }
+
+  return `
+        <div class="recipe-meta recipe-meta--panel">
+          <div class="meta-primary">
+            ${categoryBadge}
+            <button class="print-recipe-btn button-family button-primary" id="printRecipeBtn" type="button" aria-label="Print Recipe">
+              <span class="btn-icon" aria-hidden="true">🖨️</span><span class="btn-label">Print Recipe</span>
+            </button>
+            <button class="cook-mode-btn button-family button-secondary" id="cookModeBtn" type="button" aria-pressed="false" aria-label="Cook Mode: Off">
+              <span class="btn-icon" aria-hidden="true">☕</span><span class="btn-label">Cook Mode: Off</span>
+            </button>
+            <span class="info-tooltip" id="cookModeStatus" tabindex="0" title="Turn on cook mode to keep your screen awake while cooking.">ℹ️</span>
+          </div>
+          ${renderNutritionSection(recipe)}
+        </div>`;
 }
 
 // Flattens both flat-array and {title, items}-section ingredient lists into
@@ -894,31 +937,53 @@ function updateCookModeUI() {
 
   if (!cookModeBtn || !cookModeStatus) return;
 
+  // The panel view swaps the button's plain text for an icon + .btn-label
+  // span, and the status paragraph for a hover/focus tooltip — set
+  // whichever shape is actually in the DOM instead of assuming one.
+  const cookModeLabel = cookModeBtn.querySelector('.btn-label');
+  const setLabel = (text) => {
+    if (cookModeLabel) {
+      cookModeLabel.textContent = text;
+      cookModeBtn.setAttribute('aria-label', text);
+    } else {
+      cookModeBtn.textContent = text;
+    }
+  };
+  const isTooltip = cookModeStatus.classList.contains('info-tooltip');
+  const setStatus = (text) => {
+    if (isTooltip) {
+      cookModeStatus.title = text;
+      cookModeStatus.setAttribute('aria-label', text);
+    } else {
+      cookModeStatus.textContent = text;
+    }
+  };
+
   if (!supported) {
-    cookModeBtn.textContent = 'Cook Mode Unavailable';
+    setLabel('Cook Mode Unavailable');
     cookModeBtn.disabled = true;
     cookModeBtn.classList.remove('is-active');
     cookModeBtn.setAttribute('aria-pressed', 'false');
-    cookModeStatus.textContent = 'Cook mode is not supported on this browser/device.';
+    setStatus('Cook mode is not supported on this browser/device.');
     return;
   }
 
   const isActive = cookModeEnabled && !!cookWakeLockSentinel;
-  cookModeBtn.textContent = isActive ? 'Cook Mode: On' : 'Cook Mode: Off';
+  setLabel(isActive ? 'Cook Mode: On' : 'Cook Mode: Off');
   cookModeBtn.classList.toggle('is-active', isActive);
   cookModeBtn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
 
   if (isActive) {
-    cookModeStatus.textContent = 'Your screen will stay awake while this tab is active.';
+    setStatus('Your screen will stay awake while this tab is active.');
     return;
   }
 
   if (cookModeEnabled && document.visibilityState !== 'visible') {
-    cookModeStatus.textContent = 'Return to this tab to resume cook mode.';
+    setStatus('Return to this tab to resume cook mode.');
     return;
   }
 
-  cookModeStatus.textContent = 'Turn on cook mode to keep your screen awake while cooking.';
+  setStatus('Turn on cook mode to keep your screen awake while cooking.');
 }
 
 async function requestCookWakeLock() {
@@ -1217,15 +1282,7 @@ if (pageType === 'list' && recipesEl && searchEl) {
       <article class="recipe-detail">
         <h1>${recipe.title}</h1>
         <p class="recipe-description">${recipe.description}</p>
-        <div class="recipe-meta">
-          <div class="meta-primary">
-            <span class="badge">${formatRecipeCategories(recipe, ' • ')}</span>
-            <button class="print-recipe-btn button-family button-primary" id="printRecipeBtn" type="button">Print Recipe</button>
-            <button class="cook-mode-btn button-family button-secondary" id="cookModeBtn" type="button" aria-pressed="false">Cook Mode: Off</button>
-          </div>
-        </div>
-        ${renderNutritionSection(recipe)}
-        <p class="cook-mode-status" id="cookModeStatus" aria-live="polite"></p>
+        ${renderRecipeMetaSection(recipe)}
         ${recipe.tags && Array.isArray(recipe.tags) && recipe.tags.length > 0 ? `<div class="recipe-tags">${recipe.tags.map(t => `<span class="tag">${t}</span>`).join('')}</div>` : ''}
         ${renderServingsControl(recipe)}
         <div class="recipe-image-outer"><img src="${getRecipeOriginalImageUrl(recipe)}" alt="${recipe.title}" class="recipe-image" id="recipe-image-zoom" style="cursor: zoom-in;"></div>
@@ -1426,15 +1483,7 @@ if (pageType === 'detail' && detailedViewEl) {
       <article class="recipe-detail">
         <h1>${recipe.title}</h1>
         <p class="recipe-description">${recipe.description}</p>
-        <div class="recipe-meta">
-          <div class="meta-primary">
-            <span class="badge">${formatRecipeCategories(recipe, ' • ')}</span>
-            <button class="print-recipe-btn button-family button-primary" id="printRecipeBtn" type="button">Print Recipe</button>
-            <button class="cook-mode-btn button-family button-secondary" id="cookModeBtn" type="button" aria-pressed="false">Cook Mode: Off</button>
-          </div>
-        </div>
-        ${renderNutritionSection(recipe)}
-        <p class="cook-mode-status" id="cookModeStatus" aria-live="polite"></p>
+        ${renderRecipeMetaSection(recipe)}
         ${recipe.tags && Array.isArray(recipe.tags) && recipe.tags.length > 0 ? `<div class="recipe-tags">${recipe.tags.map(t => `<span class="tag">${t}</span>`).join('')}</div>` : ''}
         ${renderServingsControl(recipe)}
         <div class="recipe-image-outer"><img src="${getRecipeOriginalImageUrl(recipe)}" alt="${recipe.title}" class="recipe-image" id="recipe-image-zoom" style="cursor: zoom-in;"></div>
@@ -1581,15 +1630,7 @@ if (pageType === 'abc-detail' && detailedViewEl) {
       <article class="recipe-detail">
         <h1>${recipe.title}</h1>
         <p class="recipe-description">${recipe.description}</p>
-        <div class="recipe-meta">
-          <div class="meta-primary">
-            <span class="badge">${formatRecipeCategories(recipe, ' • ')}</span>
-            <button class="print-recipe-btn button-family button-primary" id="printRecipeBtn" type="button">Print Recipe</button>
-            <button class="cook-mode-btn button-family button-secondary" id="cookModeBtn" type="button" aria-pressed="false">Cook Mode: Off</button>
-          </div>
-        </div>
-        ${renderNutritionSection(recipe)}
-        <p class="cook-mode-status" id="cookModeStatus" aria-live="polite"></p>
+        ${renderRecipeMetaSection(recipe)}
         ${recipe.tags && Array.isArray(recipe.tags) && recipe.tags.length > 0 ? `<div class="recipe-tags">${recipe.tags.map(t => `<span class="tag">${t}</span>`).join('')}</div>` : ''}
         ${renderServingsControl(recipe)}
         <div class="recipe-image-outer"><img src="${getRecipeOriginalImageUrl(recipe)}" alt="${recipe.title}" class="recipe-image" id="recipe-image-zoom" style="cursor: zoom-in;"></div>

--- a/feature-flags.js
+++ b/feature-flags.js
@@ -14,4 +14,9 @@ window.featureFlags = {
     description: "Show nutrition facts computed from structured ingredients, instead of (or alongside) the manually entered fields.",
     default: true,
   },
+  nutritionPanelView: {
+    label: "Condensed nutrition panel",
+    description: "Show a condensed, color-coded stat panel instead of the plain nutrition list on the recipe detail page.",
+    default: false,
+  },
 };

--- a/flags.html
+++ b/flags.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="page-type" content="flags" />
   <title>Feature Flags • JoMama's Recipes</title>
-  <link rel="stylesheet" href="styles.css?v=9" />
+  <link rel="stylesheet" href="styles.css?v=10" />
   <link rel="preload" href="images/background-wood.png" as="image" type="image/png" />
 </head>
 <body class="about-page">

--- a/flags.html
+++ b/flags.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="page-type" content="flags" />
   <title>Feature Flags • JoMama's Recipes</title>
-  <link rel="stylesheet" href="styles.css?v=10" />
+  <link rel="stylesheet" href="styles.css?v=11" />
   <link rel="preload" href="images/background-wood.png" as="image" type="image/png" />
 </head>
 <body class="about-page">

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>JoMama's Recipes</title>
-  <link rel="stylesheet" href="styles.css?v=9" />
+  <link rel="stylesheet" href="styles.css?v=10" />
   <link rel="preload" href="images/background-wood.png" as="image" type="image/png" />
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>JoMama's Recipes</title>
-  <link rel="stylesheet" href="styles.css?v=10" />
+  <link rel="stylesheet" href="styles.css?v=11" />
   <link rel="preload" href="images/background-wood.png" as="image" type="image/png" />
 </head>
 <body>

--- a/kitchen-basics-oils-fats.html
+++ b/kitchen-basics-oils-fats.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="page-type" content="kitchen-basics-oils-fats" />
   <title>Kitchen Basics: Oils & Fats • JoMama's Recipes</title>
-  <link rel="stylesheet" href="styles.css?v=10" />
+  <link rel="stylesheet" href="styles.css?v=11" />
   <link rel="preload" href="images/background-wood.png" as="image" type="image/png" />
 </head>
 <body>

--- a/kitchen-basics-oils-fats.html
+++ b/kitchen-basics-oils-fats.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="page-type" content="kitchen-basics-oils-fats" />
   <title>Kitchen Basics: Oils & Fats • JoMama's Recipes</title>
-  <link rel="stylesheet" href="styles.css?v=9" />
+  <link rel="stylesheet" href="styles.css?v=10" />
   <link rel="preload" href="images/background-wood.png" as="image" type="image/png" />
 </head>
 <body>

--- a/nutrition-info.html
+++ b/nutrition-info.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="page-type" content="nutrition-info" />
   <title>Nutrition Info • JoMama's Recipes</title>
-  <link rel="stylesheet" href="styles.css?v=9" />
+  <link rel="stylesheet" href="styles.css?v=10" />
   <link rel="preload" href="images/background-wood.png" as="image" type="image/png" />
 </head>
 <body>

--- a/nutrition-info.html
+++ b/nutrition-info.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="page-type" content="nutrition-info" />
   <title>Nutrition Info • JoMama's Recipes</title>
-  <link rel="stylesheet" href="styles.css?v=10" />
+  <link rel="stylesheet" href="styles.css?v=11" />
   <link rel="preload" href="images/background-wood.png" as="image" type="image/png" />
 </head>
 <body>

--- a/recipe-detail.html
+++ b/recipe-detail.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="page-type" content="detail" />
   <title>Recipe • JoMama's Recipes</title>
-  <link rel="stylesheet" href="styles.css?v=10" />
+  <link rel="stylesheet" href="styles.css?v=11" />
   <link rel="preload" href="images/background-wood.png" as="image" type="image/png" />
 </head>
 <body>

--- a/recipe-detail.html
+++ b/recipe-detail.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="page-type" content="detail" />
   <title>Recipe • JoMama's Recipes</title>
-  <link rel="stylesheet" href="styles.css?v=9" />
+  <link rel="stylesheet" href="styles.css?v=10" />
   <link rel="preload" href="images/background-wood.png" as="image" type="image/png" />
 </head>
 <body>

--- a/recipes-list.html
+++ b/recipes-list.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="page-type" content="list" />
   <title>Recipes • JoMama's Recipes</title>
-  <link rel="stylesheet" href="styles.css?v=9" />
+  <link rel="stylesheet" href="styles.css?v=10" />
   <link rel="preload" href="images/background-wood.png" as="image" type="image/png" />
 </head>
 <body>

--- a/recipes-list.html
+++ b/recipes-list.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="page-type" content="list" />
   <title>Recipes • JoMama's Recipes</title>
-  <link rel="stylesheet" href="styles.css?v=10" />
+  <link rel="stylesheet" href="styles.css?v=11" />
   <link rel="preload" href="images/background-wood.png" as="image" type="image/png" />
 </head>
 <body>

--- a/styles.css
+++ b/styles.css
@@ -1180,10 +1180,49 @@ body{
   flex-wrap: wrap;
 }
 
+.recipe-meta--panel {
+  align-items: flex-start;
+  gap: var(--space-2-5);
+}
+
 .meta-primary {
   display: inline-flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: var(--space-2-5);
+}
+
+.btn-icon {
+  font-size: 1em;
+}
+
+.info-tooltip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  font-size: 13px;
+  line-height: 1;
+  cursor: help;
+}
+
+.info-tooltip:focus-visible {
+  outline: 2px solid var(--color-teal);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+
+@media (max-width: 480px) {
+  .recipe-meta--panel .btn-label {
+    display: none;
+  }
+
+  .recipe-meta--panel .print-recipe-btn,
+  .recipe-meta--panel .cook-mode-btn {
+    padding: var(--space-2);
+    gap: 0;
+  }
 }
 
 .badge {
@@ -1301,9 +1340,15 @@ body{
   font-size: 16px;
 }
 
+.recipe-nutrition--panel {
+  flex: 1 1 240px;
+  max-width: 280px;
+  margin: 0 0 0 auto;
+}
+
 .nutrition-panel-grid {
   display: grid;
-  gap: var(--space-2-5);
+  gap: var(--space-1-5);
   --nutrition-calories: #b5541a;
   --nutrition-calories-bg: #fbe9db;
   --nutrition-carbs: #7a4fa3;
@@ -1317,13 +1362,14 @@ body{
 .nutrition-panel-macros {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: var(--space-2-5);
+  gap: var(--space-1-5);
 }
 
 .nutrition-stat {
-  border-radius: var(--radius-md);
-  padding: var(--space-3) var(--space-2) var(--space-2-5);
-  min-height: 88px;
+  position: relative;
+  border-radius: var(--radius-sm);
+  padding: var(--space-1-5) var(--space-1);
+  min-height: 56px;
   text-align: center;
   display: flex;
   flex-direction: column;
@@ -1331,27 +1377,27 @@ body{
 }
 
 .nutrition-stat-label {
-  font-size: var(--font-size-2xs);
+  font-size: 10px;
   font-weight: 700;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.03em;
   text-transform: uppercase;
   opacity: 0.75;
-  margin-bottom: var(--space-1);
+  margin-bottom: 2px;
 }
 
 .nutrition-stat-value {
-  font-size: 22px;
+  font-size: 17px;
   font-weight: 800;
   line-height: 1.1;
 }
 
 .nutrition-stat-unit {
-  font-size: var(--font-size-smd);
+  font-size: var(--font-size-2xs);
   font-weight: 600;
 }
 
 .nutrition-stat-sub {
-  font-size: var(--font-size-2xs);
+  font-size: 10px;
   font-weight: 600;
   opacity: 0.65;
   margin-top: 2px;
@@ -1360,6 +1406,16 @@ body{
 .nutrition-stat-calories {
   background: var(--nutrition-calories-bg);
   color: var(--nutrition-calories);
+  padding-right: 22px;
+}
+
+.nutrition-stat-calories .nutrition-info-link {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  margin-left: 0;
+  font-size: 12px;
+  line-height: 1;
 }
 
 .nutrition-stat-carbs {
@@ -1368,7 +1424,7 @@ body{
 }
 
 .nutrition-stat-carbs .nutrition-stat-value {
-  font-size: 26px;
+  font-size: 19px;
 }
 
 .nutrition-stat-protein {
@@ -1601,6 +1657,7 @@ body{
   .header,
   .detail-controls,
   .cook-mode-status,
+  .info-tooltip,
   .recipe-nav,
   .image-modal,
   .print-recipe-btn,

--- a/styles.css
+++ b/styles.css
@@ -1301,6 +1301,86 @@ body{
   font-size: 16px;
 }
 
+.nutrition-panel-grid {
+  display: grid;
+  gap: var(--space-2-5);
+  --nutrition-calories: #b5541a;
+  --nutrition-calories-bg: #fbe9db;
+  --nutrition-carbs: #7a4fa3;
+  --nutrition-carbs-bg: #f0e6f7;
+  --nutrition-protein: #0f7a5c;
+  --nutrition-protein-bg: #e4f3ec;
+  --nutrition-fat: #995900;
+  --nutrition-fat-bg: #fbf3d6;
+}
+
+.nutrition-panel-macros {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-2-5);
+}
+
+.nutrition-stat {
+  border-radius: var(--radius-md);
+  padding: var(--space-3) var(--space-2) var(--space-2-5);
+  min-height: 88px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.nutrition-stat-label {
+  font-size: var(--font-size-2xs);
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  opacity: 0.75;
+  margin-bottom: var(--space-1);
+}
+
+.nutrition-stat-value {
+  font-size: 22px;
+  font-weight: 800;
+  line-height: 1.1;
+}
+
+.nutrition-stat-unit {
+  font-size: var(--font-size-smd);
+  font-weight: 600;
+}
+
+.nutrition-stat-sub {
+  font-size: var(--font-size-2xs);
+  font-weight: 600;
+  opacity: 0.65;
+  margin-top: 2px;
+}
+
+.nutrition-stat-calories {
+  background: var(--nutrition-calories-bg);
+  color: var(--nutrition-calories);
+}
+
+.nutrition-stat-carbs {
+  background: var(--nutrition-carbs-bg);
+  color: var(--nutrition-carbs);
+}
+
+.nutrition-stat-carbs .nutrition-stat-value {
+  font-size: 26px;
+}
+
+.nutrition-stat-protein {
+  background: var(--nutrition-protein-bg);
+  color: var(--nutrition-protein);
+}
+
+.nutrition-stat-fat {
+  background: var(--nutrition-fat-bg);
+  color: var(--nutrition-fat);
+}
+
 .nutrition-disclaimer {
   font-size: var(--font-size-sm);
   color: var(--color-text-muted);


### PR DESCRIPTION
Adds a nutritionPanelView feature flag that swaps the plain nutrition
list for a stat-tile panel: calories full-width, then net carbs (with
its carbs-minus-fiber breakdown), protein, and fat in a 3-column row,
each color-coded. Falls back to gross carbs when computed nutrition is
off, since net carbs needs the fiber figure. Reworked renderNutritionSection
around a shared raw-values object so both views draw from one source.

Recolored protein to the mockup's own unused green and darkened the
fat gold a step for accessibility (the original purple/blue pairing was
too close for colorblind and low-vision readers, and the gold's contrast
against its own tile background undershot 3:1) -- validated with the
dataviz skill's palette checker.