### PR TITLE
Fix hero heading wrap on narrow phone screens

### DIFF
--- a/abc-recipe-detail.html
+++ b/abc-recipe-detail.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="page-type" content="abc-detail" />
   <title>Recipe • Adrien's Baking Corner</title>
-  <link rel="stylesheet" href="styles.css?v=11" />
+  <link rel="stylesheet" href="styles.css?v=12" />
   <link rel="preload" href="images/background-wood.png" as="image" type="image/png" />
 </head>
 <body>

--- a/abc-recipe-detail.html
+++ b/abc-recipe-detail.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="page-type" content="abc-detail" />
   <title>Recipe • Adrien's Baking Corner</title>
-  <link rel="stylesheet" href="styles.css?v=12" />
+  <link rel="stylesheet" href="styles.css?v=13" />
   <link rel="preload" href="images/background-wood.png" as="image" type="image/png" />
 </head>
 <body>

--- a/abc-recipe-detail.html
+++ b/abc-recipe-detail.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="page-type" content="abc-detail" />
   <title>Recipe • Adrien's Baking Corner</title>
-  <link rel="stylesheet" href="styles.css?v=10" />
+  <link rel="stylesheet" href="styles.css?v=11" />
   <link rel="preload" href="images/background-wood.png" as="image" type="image/png" />
 </head>
 <body>

--- a/abc.html
+++ b/abc.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="page-type" content="abc" />
   <title>Adrien's Baking Corner • JoMama's Recipes</title>
-  <link rel="stylesheet" href="styles.css?v=12" />
+  <link rel="stylesheet" href="styles.css?v=13" />
   <link rel="preload" href="images/background-wood.png" as="image" type="image/png" />
 </head>
 <body>

--- a/abc.html
+++ b/abc.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="page-type" content="abc" />
   <title>Adrien's Baking Corner • JoMama's Recipes</title>
-  <link rel="stylesheet" href="styles.css?v=11" />
+  <link rel="stylesheet" href="styles.css?v=12" />
   <link rel="preload" href="images/background-wood.png" as="image" type="image/png" />
 </head>
 <body>

--- a/abc.html
+++ b/abc.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="page-type" content="abc" />
   <title>Adrien's Baking Corner • JoMama's Recipes</title>
-  <link rel="stylesheet" href="styles.css?v=10" />
+  <link rel="stylesheet" href="styles.css?v=11" />
   <link rel="preload" href="images/background-wood.png" as="image" type="image/png" />
 </head>
 <body>

--- a/about.html
+++ b/about.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="page-type" content="about" />
   <title>About • JoMama's Recipes</title>
-  <link rel="stylesheet" href="styles.css?v=12" />
+  <link rel="stylesheet" href="styles.css?v=13" />
   <link rel="preload" href="images/background-wood.png" as="image" type="image/png" />
 </head>
 <body class="about-page">

--- a/about.html
+++ b/about.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="page-type" content="about" />
   <title>About • JoMama's Recipes</title>
-  <link rel="stylesheet" href="styles.css?v=11" />
+  <link rel="stylesheet" href="styles.css?v=12" />
   <link rel="preload" href="images/background-wood.png" as="image" type="image/png" />
 </head>
 <body class="about-page">

--- a/about.html
+++ b/about.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="page-type" content="about" />
   <title>About • JoMama's Recipes</title>
-  <link rel="stylesheet" href="styles.css?v=10" />
+  <link rel="stylesheet" href="styles.css?v=11" />
   <link rel="preload" href="images/background-wood.png" as="image" type="image/png" />
 </head>
 <body class="about-page">

--- a/flags.html
+++ b/flags.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="page-type" content="flags" />
   <title>Feature Flags • JoMama's Recipes</title>
-  <link rel="stylesheet" href="styles.css?v=11" />
+  <link rel="stylesheet" href="styles.css?v=12" />
   <link rel="preload" href="images/background-wood.png" as="image" type="image/png" />
 </head>
 <body class="about-page">

--- a/flags.html
+++ b/flags.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="page-type" content="flags" />
   <title>Feature Flags • JoMama's Recipes</title>
-  <link rel="stylesheet" href="styles.css?v=12" />
+  <link rel="stylesheet" href="styles.css?v=13" />
   <link rel="preload" href="images/background-wood.png" as="image" type="image/png" />
 </head>
 <body class="about-page">

--- a/flags.html
+++ b/flags.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="page-type" content="flags" />
   <title>Feature Flags • JoMama's Recipes</title>
-  <link rel="stylesheet" href="styles.css?v=10" />
+  <link rel="stylesheet" href="styles.css?v=11" />
   <link rel="preload" href="images/background-wood.png" as="image" type="image/png" />
 </head>
 <body class="about-page">

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>JoMama's Recipes</title>
-  <link rel="stylesheet" href="styles.css?v=12" />
+  <link rel="stylesheet" href="styles.css?v=13" />
   <link rel="preload" href="images/background-wood.png" as="image" type="image/png" />
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>JoMama's Recipes</title>
-  <link rel="stylesheet" href="styles.css?v=10" />
+  <link rel="stylesheet" href="styles.css?v=11" />
   <link rel="preload" href="images/background-wood.png" as="image" type="image/png" />
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>JoMama's Recipes</title>
-  <link rel="stylesheet" href="styles.css?v=11" />
+  <link rel="stylesheet" href="styles.css?v=12" />
   <link rel="preload" href="images/background-wood.png" as="image" type="image/png" />
 </head>
 <body>

--- a/kitchen-basics-oils-fats.html
+++ b/kitchen-basics-oils-fats.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="page-type" content="kitchen-basics-oils-fats" />
   <title>Kitchen Basics: Oils & Fats • JoMama's Recipes</title>
-  <link rel="stylesheet" href="styles.css?v=11" />
+  <link rel="stylesheet" href="styles.css?v=12" />
   <link rel="preload" href="images/background-wood.png" as="image" type="image/png" />
 </head>
 <body>

--- a/kitchen-basics-oils-fats.html
+++ b/kitchen-basics-oils-fats.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="page-type" content="kitchen-basics-oils-fats" />
   <title>Kitchen Basics: Oils & Fats • JoMama's Recipes</title>
-  <link rel="stylesheet" href="styles.css?v=10" />
+  <link rel="stylesheet" href="styles.css?v=11" />
   <link rel="preload" href="images/background-wood.png" as="image" type="image/png" />
 </head>
 <body>

--- a/kitchen-basics-oils-fats.html
+++ b/kitchen-basics-oils-fats.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="page-type" content="kitchen-basics-oils-fats" />
   <title>Kitchen Basics: Oils & Fats • JoMama's Recipes</title>
-  <link rel="stylesheet" href="styles.css?v=12" />
+  <link rel="stylesheet" href="styles.css?v=13" />
   <link rel="preload" href="images/background-wood.png" as="image" type="image/png" />
 </head>
 <body>

--- a/nutrition-info.html
+++ b/nutrition-info.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="page-type" content="nutrition-info" />
   <title>Nutrition Info • JoMama's Recipes</title>
-  <link rel="stylesheet" href="styles.css?v=12" />
+  <link rel="stylesheet" href="styles.css?v=13" />
   <link rel="preload" href="images/background-wood.png" as="image" type="image/png" />
 </head>
 <body>

--- a/nutrition-info.html
+++ b/nutrition-info.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="page-type" content="nutrition-info" />
   <title>Nutrition Info • JoMama's Recipes</title>
-  <link rel="stylesheet" href="styles.css?v=11" />
+  <link rel="stylesheet" href="styles.css?v=12" />
   <link rel="preload" href="images/background-wood.png" as="image" type="image/png" />
 </head>
 <body>

--- a/nutrition-info.html
+++ b/nutrition-info.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="page-type" content="nutrition-info" />
   <title>Nutrition Info • JoMama's Recipes</title>
-  <link rel="stylesheet" href="styles.css?v=10" />
+  <link rel="stylesheet" href="styles.css?v=11" />
   <link rel="preload" href="images/background-wood.png" as="image" type="image/png" />
 </head>
 <body>

--- a/recipe-detail.html
+++ b/recipe-detail.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="page-type" content="detail" />
   <title>Recipe • JoMama's Recipes</title>
-  <link rel="stylesheet" href="styles.css?v=10" />
+  <link rel="stylesheet" href="styles.css?v=11" />
   <link rel="preload" href="images/background-wood.png" as="image" type="image/png" />
 </head>
 <body>

--- a/recipe-detail.html
+++ b/recipe-detail.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="page-type" content="detail" />
   <title>Recipe • JoMama's Recipes</title>
-  <link rel="stylesheet" href="styles.css?v=12" />
+  <link rel="stylesheet" href="styles.css?v=13" />
   <link rel="preload" href="images/background-wood.png" as="image" type="image/png" />
 </head>
 <body>

--- a/recipe-detail.html
+++ b/recipe-detail.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="page-type" content="detail" />
   <title>Recipe • JoMama's Recipes</title>
-  <link rel="stylesheet" href="styles.css?v=11" />
+  <link rel="stylesheet" href="styles.css?v=12" />
   <link rel="preload" href="images/background-wood.png" as="image" type="image/png" />
 </head>
 <body>

--- a/recipes-list.html
+++ b/recipes-list.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="page-type" content="list" />
   <title>Recipes • JoMama's Recipes</title>
-  <link rel="stylesheet" href="styles.css?v=12" />
+  <link rel="stylesheet" href="styles.css?v=13" />
   <link rel="preload" href="images/background-wood.png" as="image" type="image/png" />
 </head>
 <body>

--- a/recipes-list.html
+++ b/recipes-list.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="page-type" content="list" />
   <title>Recipes • JoMama's Recipes</title>
-  <link rel="stylesheet" href="styles.css?v=11" />
+  <link rel="stylesheet" href="styles.css?v=12" />
   <link rel="preload" href="images/background-wood.png" as="image" type="image/png" />
 </head>
 <body>

--- a/recipes-list.html
+++ b/recipes-list.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="page-type" content="list" />
   <title>Recipes • JoMama's Recipes</title>
-  <link rel="stylesheet" href="styles.css?v=10" />
+  <link rel="stylesheet" href="styles.css?v=11" />
   <link rel="preload" href="images/background-wood.png" as="image" type="image/png" />
 </head>
 <body>

--- a/styles.css
+++ b/styles.css
@@ -1669,7 +1669,7 @@ body{
   }
 
   .hero h1 {
-    font-size: clamp(20px, 6.5vw, var(--font-size-2xl));
+    font-size: clamp(17px, 5.2vw, 22px);
   }
 
   .hero p {

--- a/styles.css
+++ b/styles.css
@@ -1603,7 +1603,7 @@ body{
 .hero {
   width: 100%;
   margin: -30px auto var(--space-2);
-  height: 280px;
+  min-height: 280px;
   padding: 0 var(--space-5);
   display: flex;
   align-items: center;
@@ -1658,7 +1658,7 @@ body{
 
 @media (max-width: 768px) {
   .hero {
-    height: 330px;
+    min-height: 330px;
     margin: -10px auto var(--space-1-5);
     flex-direction: column;
     justify-content: center;
@@ -1668,7 +1668,7 @@ body{
   }
 
   .hero h1 {
-    font-size: var(--font-size-2xl);
+    font-size: clamp(20px, 6.5vw, var(--font-size-2xl));
   }
 
   .hero p {

--- a/styles.css
+++ b/styles.css
@@ -1622,6 +1622,7 @@ body{
   letter-spacing: -0.02em;
   color: var(--color-teal);
   font-family: "Times New Roman", Times, serif;
+  text-wrap: balance;
 }
 
 .hero p {


### PR DESCRIPTION
The hero h1 used a fixed font-size that only fit on one line at
iPhone-width viewports; narrower phones (e.g. Pixel) wrapped to two
lines, and the fixed-height .hero box had no room for that, so the
text spilled past its background. Scale the heading with clamp() so
it shrinks gracefully on narrow screens, and switch .hero to
min-height so it can never overflow if wrapping happens anyway.

Bump styles.css cache-busting version per CLAUDE.md.