### PR TITLE
Add Beef Stroganoff recipe

### DIFF
--- a/data/ingredient-nutrition.js
+++ b/data/ingredient-nutrition.js
@@ -2009,4 +2009,59 @@ window.ingredientNutrition = {
     verified: true,
     source: "Mission Carb Balance Flour Tortilla (burrito size) label: 110 cal / 6g fat / 28g fiber / 32g carbs / 10g protein per 1 tortilla (71g), per user-provided photo."
   },
+  "egg noodles": {
+    per: "100g",
+    calories: 375,
+    protein: 12.5,
+    fat: 4.5,
+    fiber: 3,
+    carbs: 73,
+    unitWeights: {},
+    verified: false,
+    source: "Estimated by Claude (typical USDA FoodData Central / brand-label values for dry egg noodles), unverified, pending user review"
+  },
+  "ground beef (80/20)": {
+    per: "100g",
+    calories: 254,
+    protein: 17.2,
+    fat: 20,
+    fiber: 0,
+    carbs: 0,
+    unitWeights: {},
+    verified: false,
+    source: "Estimated by Claude (USDA FoodData Central, ground beef 80% lean / 20% fat, raw), unverified, pending user review"
+  },
+  "cremini mushrooms": {
+    per: "100g",
+    calories: 22,
+    protein: 3.1,
+    fat: 0.3,
+    fiber: 1,
+    carbs: 3.3,
+    unitWeights: {},
+    verified: false,
+    source: "Estimated by Claude (typical USDA FoodData Central / brand-label values for crimini/baby bella mushrooms), unverified, pending user review"
+  },
+  "yellow onion": {
+    per: "100g",
+    calories: 40,
+    protein: 1.1,
+    fat: 0.1,
+    fiber: 1.7,
+    carbs: 9.3,
+    unitWeights: { "yellow onion": 150 },
+    verified: false,
+    source: "Estimated by Claude (typical USDA FoodData Central / brand-label values), unverified, pending user review"
+  },
+  "butter": {
+    per: "100g",
+    calories: 714,
+    protein: 0,
+    fat: 78.6,
+    fiber: 0,
+    carbs: 0,
+    unitWeights: {},
+    verified: false,
+    source: "Estimated by Claude (typical USDA FoodData Central / brand-label values), unverified, pending user review"
+  },
 };

--- a/data/units.js
+++ b/data/units.js
@@ -137,6 +137,7 @@ window.unitConversions = {
     "baby crispy green leaf lettuce": 0.136,
     "reduced fat fiesta blend cheese": 0.47,
     "crispy tortilla strips": 0.24,
+    "butter": 0.95,
   },
 
   // Preferred display units for the US/Metric units toggle (units-service.js).

--- a/recipes-data.js
+++ b/recipes-data.js
@@ -2131,4 +2131,55 @@ tags: ["dessert", "high protein"]
   ]
 },
 
+{
+  id: "beef-stroganoff",
+  title: "Beef Stroganoff",
+  description: "Bold, savory ground beef stroganoff with deeply browned mushrooms, a tangy Worcestershire Dijon kick, and a rich sour cream finish over egg noodles.",
+  image: "images/no-photo.jpg",
+  category: ["Beef", "Pasta"],
+  dateAdded: "2026-07-29",
+  carbs: null,
+  fat: null,
+  fiber: null,
+  calories: "",
+  protein: "",
+  servings: "6",
+  tags: ["beef", "ground beef", "mushrooms", "stroganoff", "egg noodles", "comfort food", "weeknight"],
+
+  ingredients: [
+    { qty: 12, unit: "oz", name: "egg noodles" },
+
+    { qty: 1.5, unit: "lb", name: "ground beef (80/20)" },
+    { qty: 16, unit: "oz", name: "cremini mushrooms", notes: "or baby bella, sliced thick" },
+    { qty: 1, unit: null, name: "yellow onion", notes: "diced" },
+    { qty: 4, unit: "clove", name: "garlic", notes: "minced" },
+
+    { qty: 2, unit: "cup", name: "beef broth" },
+    { qty: 3, unit: "tbsp", name: "worcestershire sauce" },
+    { qty: 2, unit: "tbsp", name: "dijon mustard" },
+    { qty: 0.75, unit: "cup", name: "sour cream" },
+    { qty: 2, unit: "tbsp", name: "butter" },
+    { qty: 2, unit: "tbsp", name: "olive oil" },
+    { qty: 1.5, unit: "tsp", name: "kosher salt" },
+    { qty: 1, unit: "tsp", name: "black pepper", notes: "plus more to finish" },
+
+    { qty: 2, unit: "tbsp", name: "fresh chopped parsley", notes: "for garnish" }
+  ],
+
+  steps: [
+    "Cook the noodles: bring a large pot of salted water to a boil and cook the egg noodles according to package directions until al dente. Drain and set aside.",
+    "Brown the mushrooms: heat the olive oil in a large skillet over medium-high heat. Add the mushrooms in a single layer and let sit undisturbed for 3 to 4 minutes until deeply browned before stirring. Cook until golden all over, about 8 minutes total. Remove the mushrooms to a plate and set aside.",
+    "Brown the beef: in the same skillet, add the ground beef. Press it into an even layer and let it sit undisturbed for 3 to 4 minutes to build a deep brown crust on the bottom of the pan before breaking it up. Continue cooking until fully browned, about 8 minutes.",
+    "Build the aromatics: add the onion to the beef and cook 4 to 5 minutes until softened. Add the garlic and cook 30 seconds until fragrant.",
+    "Deglaze and simmer: pour in the beef broth, scraping up all the browned bits from the bottom of the pan. Stir in the Worcestershire sauce, Dijon mustard, salt, and pepper. Bring to a simmer and cook uncovered for 8 to 10 minutes, until slightly reduced.",
+    "Bring it together: return the reserved mushrooms to the pan and stir in the butter. Reduce the heat to low and stir in the sour cream until fully incorporated. Do not let it boil once the sour cream is in, or it may break.",
+    "Serve: spoon the beef and mushroom sauce over the cooked egg noodles. Finish with extra cracked pepper and parsley."
+  ],
+
+  notes: [
+    "For extra depth, deglaze with a splash of dry white wine before adding the broth.",
+    "Leftovers keep 3 to 4 days in the fridge; reheat gently over low heat, since sour cream sauces can break if boiled."
+  ]
+},
+
 ];


### PR DESCRIPTION
Ground beef stroganoff with browned mushrooms, Worcestershire Dijon
sauce, and sour cream over egg noodles. Uses the no-photo placeholder
image pending the real photo.

Adds nutrition entries for egg noodles, ground beef (80/20), cremini
mushrooms, yellow onion, and butter (all estimated, unverified) since
none existed in the database yet.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LoWqS5ALLCbbMgwzy5Z21j