### PR TITLE
Add Vidalia onions nutrition entry

### DIFF
--- a/data/ingredient-nutrition.js
+++ b/data/ingredient-nutrition.js
@@ -2075,4 +2075,15 @@ window.ingredientNutrition = {
     verified: false,
     source: "Estimated by Claude (typical USDA FoodData Central / brand-label values), unverified, pending user review"
   },
+  "vidalia onions": {
+    per: "100g",
+    calories: 40,
+    protein: 1.1,
+    fat: 0.1,
+    fiber: 1.7,
+    carbs: 9.3,
+    unitWeights: {},
+    verified: false,
+    source: "Estimated by Claude (typical USDA FoodData Central / brand-label values for sweet onions), unverified, pending user review"
+  },
 };


### PR DESCRIPTION
The onion rename in the French onion soup recipe left "Vidalia onions"
unmatched in the nutrition database, so the whole recipe's nutrition
info fell back to Unknown (any single unresolved ingredient blanks all
fields). Vidalia is a sweet onion variety with the same typical
macros as yellow/sweet onions already in the database.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TXesJ7mQEr7RMz1gJfApcM